### PR TITLE
The lofi stream url changed

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
 
-export const URL = 'https://www.youtube.com/watch?v=5qap5aO4i9A'
+export const URL = 'https://www.youtube.com/watch?v=jfKfPfyJRdk'
 
 export const DOWNLOADS_DIR_NAME = 'downloads'


### PR DESCRIPTION
There were some problems with youtube and the lofi channel so the stream URL changed.

The old URL is not working anymore and the script fails.

This pull request updates the URL to the new working one.